### PR TITLE
BAU: Generate metadata for Proxy Node

### DIFF
--- a/features/generate_help.feature
+++ b/features/generate_help.feature
@@ -9,6 +9,7 @@ Feature: generate help
       """
       Usage: generate_metadata [options]
           -r, --connector                  the environment is for eIDAS connector
+          -p, --proxy-node                 the environment is for eIDAS proxy node
           -e, --env=ENVIRONMENT            environment to generate metadata for
           -cDIRECTORY                      the input directory to use
           -w                               write the metadata to a file at ENVIRONMENT/metadata.xml

--- a/features/validates_hub_input.feature
+++ b/features/validates_hub_input.feature
@@ -24,7 +24,7 @@ Feature: Validates Hub Input
     And the stderr should contain
     """
     file with name 'hub.yml' had the following errors:
-    The property '#/' of type null did not match the following type: object in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
+    The property '#/' of type null did not match the following type: object in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
     """
 
   Scenario: When the input file is missing keys
@@ -40,12 +40,12 @@ Feature: Validates Hub Input
     And the stderr should contain
     """
     file with name 'hub.yml' had the following errors:
-    The property '#/' did not contain a required property of 'id' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
-    The property '#/' did not contain a required property of 'entity_id' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
-    The property '#/' did not contain a required property of 'assertion_consumer_service_uri' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
-    The property '#/' did not contain a required property of 'organization' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
-    The property '#/' did not contain a required property of 'signing_certificates' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
-    The property '#/' did not contain a required property of 'encryption_certificate' in schema 63bfb93a-fc9f-5141-a13f-0f81f5fdfeef
+    The property '#/' did not contain a required property of 'id' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
+    The property '#/' did not contain a required property of 'entity_id' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
+    The property '#/' did not contain a required property of 'assertion_consumer_service_uri' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
+    The property '#/' did not contain a required property of 'organization' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
+    The property '#/' did not contain a required property of 'signing_certificates' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
+    The property '#/' did not contain a required property of 'encryption_certificate' in schema 279b5ef1-bb4b-53ad-a771-a9ccfa980996
     """
 
   Scenario: When the IDP has a bad certificate

--- a/lib/verify/metadata/generator.rb
+++ b/lib/verify/metadata/generator.rb
@@ -30,6 +30,10 @@ module Verify
             hub_entity_descriptor = hub_metadata_provider.provide(environment, valid_until)
             validator.validate([hub_entity_descriptor])
             metadata_content = aggregator.generate_metadata_content(hub_entity_descriptor)
+          elsif options.is_proxy_node
+            proxy_node_entity_descriptor = idp_metadata_provider.provide(environment, valid_until).first
+            validator.validate([proxy_node_entity_descriptor])
+            metadata_content = aggregator.generate_metadata_content(proxy_node_entity_descriptor)
           else
             hub_entity_descriptor = hub_metadata_provider.provide(environment)
             idp_entity_descriptors = idp_metadata_provider.provide(environment)

--- a/lib/verify/metadata/generator/arguments_parser.rb
+++ b/lib/verify/metadata/generator/arguments_parser.rb
@@ -3,7 +3,7 @@ module Verify
   module Metadata
     module Generator
       class ArgumentsParser
-        Options = Struct.new(:environments, :input_directory, :write_file, :is_connector, :output_directory, :valid_until, :idp_ca_files, :hub_ca_files) do
+        Options = Struct.new(:environments, :input_directory, :write_file, :is_connector, :is_proxy_node, :output_directory, :valid_until, :idp_ca_files, :hub_ca_files) do
           def validate!
             raise "environment must be set!" if environments.empty?
           end
@@ -13,6 +13,7 @@ module Verify
           options = Options.new
           options.write_file = false
           options.is_connector = false
+          options.is_proxy_node = false
           options.output_directory = File.absolute_path(Dir.pwd)
           options.environments = []
           options.idp_ca_files = []
@@ -23,6 +24,10 @@ module Verify
 
             opts.on("-r", "--connector", "the environment is for eIDAS connector") do
               options.is_connector = true
+            end
+
+            opts.on("-p", "--proxy-node", "the environment is for eIDAS proxy node") do
+              options.is_proxy_node = true
             end
 
             opts.on("-eENVIRONMENT", "--env=ENVIRONMENT", String, "environment to generate metadata for") do |env|

--- a/lib/verify/metadata/generator/schema.rb
+++ b/lib/verify/metadata/generator/schema.rb
@@ -5,8 +5,8 @@ module Verify
       module Schema
         HUB = JSON.parse <<JSON
 {
-  "title":"IDP",
-  "description":"The necessary configuration for an IDP",
+  "title":"HUB",
+  "description":"The necessary configuration for a HUB",
   "type":"object",
   "required": ["id", "entity_id", "assertion_consumer_service_uri", "organization", "signing_certificates", "encryption_certificate"],
   "definitions": {

--- a/spec/ida/metadata/generator/idp_metadata_provider_spec.rb
+++ b/spec/ida/metadata/generator/idp_metadata_provider_spec.rb
@@ -21,8 +21,8 @@ module Verify
             expect(fake_yaml_loader).to receive(:load).with("test_env/idps/*.yml").and_return([LoadedYaml.new(an_idp_hash, double(:name)), LoadedYaml.new(an_other_idp_hash, double(:name))])
             expect(an_idp_hash).to receive(:[]).with("enabled").and_return(true)
             expect(an_other_idp_hash).to receive(:[]).with("enabled").and_return(false)
-            expect(fake_entity_descriptor_converter).to receive(:generate).with(an_idp_hash).and_return(converted_idp)
-            expect(fake_entity_descriptor_converter).to_not receive(:generate).with(an_other_idp_hash)
+            expect(fake_entity_descriptor_converter).to receive(:generate).with(an_idp_hash, nil).and_return(converted_idp)
+            expect(fake_entity_descriptor_converter).to_not receive(:generate).with(an_other_idp_hash, nil)
             expect(fake_schema_validator).to receive(:validate!)
             metadata = IdpMetadataProvider.new(fake_yaml_loader, fake_schema_validator, fake_entity_descriptor_converter).provide(environment)
             expect(metadata).to eq [converted_idp]
@@ -46,7 +46,7 @@ module Verify
           converted_idp = double(:converted_idp)
           expect(fake_yaml_loader).to receive(:load).with("test_env/idps/*.yml").and_return([LoadedYaml.new(an_idp_hash, double(:name))])
           expect(an_idp_hash).to receive(:[]).with("enabled").and_return(true)
-          expect(fake_entity_descriptor_converter).to receive(:generate).with(an_idp_hash).and_return(converted_idp)
+          expect(fake_entity_descriptor_converter).to receive(:generate).with(an_idp_hash, nil).and_return(converted_idp)
           expect(fake_schema_validator).to receive(:validate!)
           metadata = IdpMetadataProvider.new(fake_yaml_loader, fake_schema_validator, fake_entity_descriptor_converter).provide(environment)
           expect(metadata).to eq [converted_idp]


### PR DESCRIPTION
The eIDAS Proxy Node requires metadata similar to that of the
Connector, except the EntityDescriptor needs to contain an
IDPSSODescriptor rather than a SPSSODescriptor.

Author: @vixus0