### PR TITLE
BAU: Change pre-commit shebang to bash

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 function exit_unless {
     exit_code=$1
     if [ ${exit_code} -ne 0 ]


### PR DESCRIPTION
The shebang in `pre-commit.sh` specifies `sh` as the shell in which
to execute but proceeds to use bash functionality. Trying to execute
this script anywhere that uses actual `sh` and doesn't just symlink it
to `bash` causes the script to fail.

Author: @vixus0