### PR TITLE
✅ EID-1977 eIDAS compliant connector metadata fixes

### DIFF
--- a/lib/verify/metadata/generator/certificate.rb
+++ b/lib/verify/metadata/generator/certificate.rb
@@ -34,6 +34,8 @@ module Verify
                 builder.X509Certificate(self.x509)
               }
             }
+            builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes256-gcm")
+            builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes128-gcm")
           }
         end
       end

--- a/lib/verify/metadata/generator/sp_descriptor.rb
+++ b/lib/verify/metadata/generator/sp_descriptor.rb
@@ -41,7 +41,8 @@ module Verify
             'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
             'protocolSupportEnumeration' => 'urn:oasis:names:tc:SAML:2.0:protocol',
             'xsi:type' => 'md:SPSSODescriptorType',
-            'WantAssertionsSigned' => true
+            'WantAssertionsSigned' => true,
+            'AuthnRequestsSigned' => true
           ) {
             encryption_certificate.append_xml(builder)
             signing_certificates.each { |signing_certificate|


### PR DESCRIPTION
Address two issues the EU Validator Node test team had with our Connector Metadata.

Their assessment was: 

> ·         The element <md:SPSSODescriptor> is missing an attribute “AuthnRequestsSigned” in the UK connector Metadata:
> According to the EIDAS specification , <md:SPSSODescriptor> element MUST contain the attribute AuthnRequestsSigned set to "true" to indicate that transmitted <saml2p:AuthnRequest> messages are signed.
> 
> ·         The UK SAML Connector Metadata do not expose the cryptographic capabilities regarding XML encryption (the element ‘EncryptionMethod’ is missing).
> According to the EIDAS specification, , eIDAS Message Format v1.1-2, section 2.1.1, “eIDAS-Nodes MUST publish their cryptographic capabilities with regards to XML Signature and XML Encryption in their SAML metadata according to [eIDAS-Crypto] and [SAML2AlgSup]”.
> 

To address this:

1) List supported encryption methods for content to be encrypted by a Proxy Node with a symmetric key, in order of preference. These are listed at https://github.com/alphagov/verify-hub/blob/1c3bb76cc9b9eb62fc3216198e546f126d632545/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java#L738-L740

2) Set `AuthnRequestsSigned="true"` in metadata, to indicate that transmitted <saml2p:AuthnRequest> messages are signed

Test locally by:
* checking out this branch, 
* `cd` to `verify-metadata`
* amend `./Gemfile` to update line with `gem 'verify-metadata-generator'` to: `gem 'verify-metadata-generator', path: "local_path_to/verify-metadata-generator"`
* run `./generate-metadata.sh -e local-connector` (using JDK8)
* the file `./signed/local-connector/metadata.xml` should contain the changes in this PR
