### PR TITLE
EID-1977 apply 'EncryptionMethod' to encryption KeyDescriptor only

### DIFF
--- a/lib/verify/metadata/generator/certificate.rb
+++ b/lib/verify/metadata/generator/certificate.rb
@@ -34,8 +34,10 @@ module Verify
                 builder.X509Certificate(self.x509)
               }
             }
-            builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes256-gcm")
-            builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes128-gcm")
+            if self.use == 'encryption'
+              builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes256-gcm")
+              builder["md"].EncryptionMethod("Algorithm" => "http://www.w3.org/2009/xmlenc11#aes128-gcm")
+            end
           }
         end
       end


### PR DESCRIPTION
The 'signing' KeyDescriptor is also being decorated with the EncryptionMethod element.
Apply the EncryptionMethod element to the 'encryption' KeyDescriptor only.

Test locally by:
* checking out this branch, 
* `cd` to `verify-metadata`
* use bundler local git repos feature to override bundle config for `verify-metadata-generator`:
`bundle config local.verify-metadata-generator /path/to/local/git/verify-metadata-generator`
* run `./generate-metadata.sh -e local-connector` (using JDK8)
* the file `./signed/local-connector/metadata.xml` should contain two `EncryptionMethod`s on the encryption KeyDescriptor only.